### PR TITLE
Add multiple function params support

### DIFF
--- a/tests/BayTest.php
+++ b/tests/BayTest.php
@@ -100,11 +100,45 @@ class BayTest extends \PHPUnit_Framework_TestCase {
 
 	//--------------------------------------------------------------------
 
+	/**
+	 * @expectedException InvalidArgumentException
+	 * @expectedExceptionMessage \SampleClass::hello has no params.
+	 */
+	public function testDisplayRendersWithInvalidParam()
+	{
+		$bay = new Bay();
+		$bay->display('\SampleClass::hello', 'one=two');
+	}
+
+	//--------------------------------------------------------------------
+
 	public function testDisplayRendersWithValidParamString()
 	{
 		$bay = new Bay();
 		$params = 'one=two,three=four';
 		$expected = ['one' => 'two', 'three' => 'four'];
+
+		$this->assertEquals($expected, $bay->display('\SampleClass::echobox', $params));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDisplayRendersWithValidOneSameNameParamString()
+	{
+		$bay = new Bay();
+		$params = 'params=two';
+		$expected = 'two';
+
+		$this->assertEquals($expected, $bay->display('\SampleClass::echobox', $params));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDisplayRendersWithValidSameNameParam()
+	{
+		$bay = new Bay();
+		$params = ['params' => 'one', 'another' => 'two'];
+		$expected = $params;
 
 		$this->assertEquals($expected, $bay->display('\SampleClass::echobox', $params));
 	}
@@ -118,6 +152,52 @@ class BayTest extends \PHPUnit_Framework_TestCase {
 		$expected = ['one' => 'two', 'three' => 'four'];
 
 		$this->assertEquals($expected, $bay->display('\SampleClass::staticEcho', $params));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDisplayRendersWithValidMultipleParamString()
+	{
+		$bay = new Bay();
+		$params = 'a=x b=y c=z';
+		$expected = 'xyz';
+
+		$this->assertEquals($expected, $bay->display('\SampleClass::multipleParams', $params));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDisplayRendersWithValidMultipleParamArray()
+	{
+		$bay = new Bay();
+		$params = ['a' => 'x', 'b' => 'y', 'c' => 'z'];
+		$expected = 'xyz';
+
+		$this->assertEquals($expected, $bay->display('\SampleClass::multipleParams', $params));
+	}
+
+	//--------------------------------------------------------------------
+
+	public function testDisplayRendersWithValidMultipleParamArrayAnotherOrder()
+	{
+		$bay = new Bay();
+		$params = ['c' => 'z', 'a' => 'x', 'b' => 'y'];
+		$expected = 'xyz';
+
+		$this->assertEquals($expected, $bay->display('\SampleClass::multipleParams', $params));
+	}
+
+	//--------------------------------------------------------------------
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 * @expectedExceptionMessage bad is not a valid param name.
+	 */
+	public function testDisplayRendersWithInvalidMultipleParamArray()
+	{
+		$bay = new Bay();
+		$params = ['a' => 'x', 'b' => 'y', 'bad' => 'z'];
+		$bay->display('\SampleClass::multipleParams', $params);
 	}
 
 	//--------------------------------------------------------------------

--- a/tests/resources/SampleClass.php
+++ b/tests/resources/SampleClass.php
@@ -10,24 +10,30 @@ class SampleClass {
 
 	public function hello()
 	{
-	    return 'Hello';
+		return 'Hello';
 	}
 
 	//--------------------------------------------------------------------
 
 	public function echobox($params)
 	{
-        return $params;
+		return $params;
 	}
 
 	//--------------------------------------------------------------------
 
 	public static function staticEcho($params)
 	{
-	    return $params;
+		return $params;
 	}
 
 	//--------------------------------------------------------------------
 
+	public static function multipleParams($a, $b, $c)
+	{
+		return $a.$b.$c;
+	}
+
+	//--------------------------------------------------------------------
 
 }


### PR DESCRIPTION
This PR enables using multiple params like this:

``` php
class Posts {
    public function recentPosts($limit, $offset) 
    { 
        $posts = $this->postModel->findLatest( $limit, $offset );
        return $this->view('recentPosts', ['posts' => $posts] );
    }
}

// In your view layer...
$bay->display("\Blog\Posts::recentPosts", "limit=5 offset=0");
// You can change the order
$bay->display("\Blog\Posts::recentPosts", "offset=0 limit=5");
```

And you can also use single array `$params` the same as before:

``` php
class Posts {
    public function recentPosts( array $params=[] ) 
    { 
        $limit = ! empty($params['limit']) ? $params['limit'] : 5;
        $offset = ! empty($params['offset']) ? $params['offset'] : 0;

        $posts = $this->postModel->findLatest( $limit, $offset );
        return $this->view('recentPosts', ['posts' => $posts] );
    }
}

// In your view layer...
$bay->display("\Blog\Posts::recentPosts", "limit=5 offset=0");
```

The only difference is the case that param array has one key and the key name is the same as functions's param name:

``` php
class Posts {
    public function recentPosts($params) 
    { 
        // $params is '5', not ['params' => '5']
    }
}

// In your view layer...
$bay->display("\Blog\Posts::recentPosts", "params=5");
```
